### PR TITLE
Fix code scanning alert no. 1: Incorrect conversion between integer types

### DIFF
--- a/api/parsers/account.go
+++ b/api/parsers/account.go
@@ -2,6 +2,8 @@ package parsers
 
 import (
 	"strconv"
+	"math"
+	"fmt"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -59,11 +61,14 @@ func ParseAccountsFilters(c *gin.Context, v *validator.Validate) (historydb.GetA
 	if accountsFilter.IDs != "" {
 		ids := strings.Split(accountsFilter.IDs, ",")
 		for _, id := range ids {
-			idUint, err := strconv.Atoi(id)
+			idInt64, err := strconv.ParseInt(id, 10, 32)
 			if err != nil {
 				return historydb.GetAccountsAPIRequest{}, err
 			}
-			tokenID := common.TokenID(idUint)
+			if idInt64 < 0 || idInt64 > math.MaxUint32 {
+				return historydb.GetAccountsAPIRequest{}, fmt.Errorf("token ID out of range: %s", id)
+			}
+			tokenID := common.TokenID(idInt64)
 			tokenIDs = append(tokenIDs, tokenID)
 		}
 	}


### PR DESCRIPTION
Fixes [https://github.com/VersoriumX/hermez-node/security/code-scanning/1](https://github.com/VersoriumX/hermez-node/security/code-scanning/1)

To fix the problem, we should replace the use of `strconv.Atoi` with `strconv.ParseInt`, specifying the bit size of the target type. Additionally, we should add bounds checking to ensure that the parsed value fits within the range of `common.TokenID`.

1. Replace `strconv.Atoi` with `strconv.ParseInt` specifying a 32-bit size.
2. Add bounds checking to ensure the parsed value is within the valid range for `common.TokenID`.
3. Update the conversion to handle errors appropriately if the bounds are exceeded.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
