### PR TITLE
Fix code scanning alert no. 3: Incorrect conversion between integer types

### DIFF
--- a/test/til/lang.go
+++ b/test/til/lang.go
@@ -319,13 +319,13 @@ func (p *parser) parseLine(setType setType) (*Instruction, error) {
 		}
 		_, lit = p.scanIgnoreWhitespace()
 		c.Literal += lit
-		tidI, err := strconv.Atoi(lit)
+		tidU, err := strconv.ParseUint(lit, 10, 32)
 		if err != nil {
 			line, _ := p.s.r.ReadString('\n')
 			c.Literal += line
 			return c, tracerr.Wrap(err)
 		}
-		c.TokenID = common.TokenID(tidI)
+		c.TokenID = common.TokenID(tidU)
 		if err := p.expectChar(c, ")"); err != nil {
 			return c, tracerr.Wrap(err)
 		}


### PR DESCRIPTION
Fixes [https://github.com/VersoriumX/hermez-node/security/code-scanning/3](https://github.com/VersoriumX/hermez-node/security/code-scanning/3)

To fix the problem, we need to ensure that the integer value parsed from the string is within the valid range for `uint32` before casting it. This can be achieved by using `strconv.ParseUint` with a specified bit size of 32, which directly parses the string into a `uint32` value and handles bounds checking.

- Replace the use of `strconv.Atoi` with `strconv.ParseUint` specifying a bit size of 32.
- Ensure that the parsed value is within the bounds of `uint32` before assigning it to `common.TokenID`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
