### PR TITLE
Fix code scanning alert no. 2: Incorrect conversion between integer types

### DIFF
--- a/api/parsers/tokens.go
+++ b/api/parsers/tokens.go
@@ -3,6 +3,7 @@ package parsers
 import (
 	"strconv"
 	"strings"
+	"math"
 
 	ethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/gin-gonic/gin"
@@ -46,9 +47,12 @@ func ParseTokensFilters(c *gin.Context) (historydb.GetTokensAPIRequest, error) {
 		ids := strings.Split(tokensFilters.IDs, "|")
 
 		for _, id := range ids {
-			idUint, err := strconv.Atoi(id)
+			idUint, err := strconv.ParseUint(id, 10, 32)
 			if err != nil {
 				return historydb.GetTokensAPIRequest{}, tracerr.Wrap(err)
+			}
+			if idUint > math.MaxUint32 {
+				return historydb.GetTokensAPIRequest{}, tracerr.New("ID value out of bounds for TokenID")
 			}
 			tokenID := common.TokenID(idUint)
 			tokensIDs = append(tokensIDs, tokenID)


### PR DESCRIPTION
Fixes [https://github.com/VersoriumX/hermez-node/security/code-scanning/2](https://github.com/VersoriumX/hermez-node/security/code-scanning/2)

To fix the problem, we need to ensure that the integer value parsed from the string is within the bounds of the `common.TokenID` type before performing the conversion. This can be achieved by using `strconv.ParseUint` with the appropriate bit size and then checking the bounds.

1. Replace the use of `strconv.Atoi` with `strconv.ParseUint` to specify the bit size explicitly.
2. Add a check to ensure that the parsed value is within the bounds of `common.TokenID` before converting it.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
