### PR TITLE
Potential fix for code scanning alert no. 5: Incorrect conversion between integer types

### DIFF
--- a/test/til/lang.go
+++ b/test/til/lang.go
@@ -509,6 +509,9 @@ func (p *parser) expectChar(c *Instruction, ch string) error {
 }
 
 func idxTokenIDToString(idx string, tid common.TokenID) string {
+	if tid > math.MaxInt32 {
+		log.Fatalf("TokenID %d exceeds maximum value for int", tid)
+	}
 	return idx + strconv.Itoa(int(tid))
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/VersoriumX/hermez-node/security/code-scanning/5](https://github.com/VersoriumX/hermez-node/security/code-scanning/5)

To fix the problem, we need to ensure that the conversion from `uint32` to `int` is safe. This can be done by performing an explicit bounds check before the conversion. If the value exceeds the maximum value that can be represented by an `int`, we should handle the error appropriately.

The best way to fix the problem is to add a bounds check before converting the `uint32` value to an `int`. We will use the `math.MaxInt32` constant to check if the value is within the acceptable range for an `int`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
